### PR TITLE
add open and delete buttons to security tests

### DIFF
--- a/src/components/ds/accordion/accordion-list.tsx
+++ b/src/components/ds/accordion/accordion-list.tsx
@@ -1,3 +1,4 @@
+import { Loading } from "../../icons/loading";
 import styles from "./accordion.module.css";
 
 export const AccordionList: React.FC<{
@@ -9,7 +10,7 @@ export const AccordionList: React.FC<{
 export const AccordionItem: React.FC<{
   icon: JSX.Element;
   title: string;
-  actions: JSX.Element[];
+  actions: JSX.Element;
 }> = ({ icon, title, actions }) => {
   return (
     <div className={styles.item}>
@@ -17,5 +18,17 @@ export const AccordionItem: React.FC<{
       <span>{title}</span>
       {actions}
     </div>
+  );
+};
+
+export const AccordionAction: React.FC<{
+  loading?: boolean;
+  icon: JSX.Element;
+  onClick?: () => void;
+}> = ({ icon, onClick, loading }) => {
+  return (
+    <button onClick={onClick} disabled={loading} className={styles.action}>
+      {loading ? <Loading /> : icon}
+    </button>
   );
 };

--- a/src/components/ds/accordion/accordion.module.css
+++ b/src/components/ds/accordion/accordion.module.css
@@ -21,12 +21,13 @@
   width: 1rem;
   height: 1rem;
   fill: var(--white);
-  transform: rotate(180deg);
+  transform: rotate(0deg);
   margin: auto 0;
+  transition: transform 250ms;
 }
 
 .accordion.active > header > svg {
-  transform: rotate(0deg);
+  transform: rotate(180deg);
 }
 
 .list {
@@ -57,4 +58,21 @@
   height: 1.25rem;
   fill: var(--white);
   flex-shrink: 0;
+}
+
+.action {
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.action > svg {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--color-primary-10);
+}
+
+.action > svg:hover {
+  fill: var(--white);
 }

--- a/src/components/ds/dialog/confirm-dialog.tsx
+++ b/src/components/ds/dialog/confirm-dialog.tsx
@@ -1,0 +1,58 @@
+import { Popover } from "@headlessui/react";
+import CloseIcon from "../../icons/close-icon";
+import styles from "./dialog.module.css";
+
+const ConfirmDialog: React.FC<{
+  message: string;
+  affirmative?: string;
+  negative?: string;
+  onAffirm: () => void;
+  onDecline?: () => void;
+  children: JSX.Element | JSX.Element[];
+}> = ({
+  message,
+  affirmative = "Yes",
+  negative = "No",
+  children,
+  onAffirm,
+  onDecline,
+}) => {
+  return (
+    <Popover className={styles.confirm}>
+      <Popover.Button as="div">{children}</Popover.Button>
+      <Popover.Panel className={styles.prompt}>
+        {({ close }) => (
+          <>
+            <div className={styles.message}>
+              <span>{message}</span>
+              <button onClick={() => close()}>
+                <CloseIcon />
+              </button>
+            </div>
+            <div className={styles.options}>
+              <button
+                onClick={() => {
+                  close();
+                  onAffirm();
+                }}
+                className={styles.approve}
+              >
+                {affirmative}
+              </button>
+              <button
+                onClick={() => {
+                  close();
+                  onDecline?.();
+                }}
+              >
+                {negative}
+              </button>
+            </div>
+          </>
+        )}
+      </Popover.Panel>
+    </Popover>
+  );
+};
+
+export default ConfirmDialog;

--- a/src/components/ds/dialog/dialog.module.css
+++ b/src/components/ds/dialog/dialog.module.css
@@ -1,39 +1,8 @@
-.copy {
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 0;
-}
-
-.copy > svg {
-  width: 1rem;
-  height: 1rem;
-  fill: var(--color-primary-10);
-}
-
-.delete {
-  border: none;
-  background: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.delete > svg {
-  width: 1rem;
-  height: 1rem;
-  fill: var(--color-primary-10);
-}
-
-.delete > svg:hover,
-.copy > svg:hover {
-  fill: var(--white);
-}
-
-.deleteContainer {
+.confirm {
   position: relative;
 }
 
-.deletePrompt {
+.prompt {
   position: absolute;
   right: -20%;
   top: 120%;
@@ -49,7 +18,7 @@
   border-radius: 4px;
 }
 
-.deletePrompt:before {
+.prompt:before {
   right: 0;
   top: -10%;
   position: absolute;
@@ -89,7 +58,7 @@
   fill: var(--white);
 }
 
-.confirmation {
+.options {
   display: flex;
   flex-direction: row;
   column-gap: 0.5rem;
@@ -98,7 +67,7 @@
   column-gap: 1rem;
 }
 
-.confirmation > button {
+.options > button {
   padding: 0.5rem 3rem;
   border: 1px solid var(--color-primary-10);
   border-radius: 0.25rem;
@@ -106,12 +75,12 @@
   background: none;
 }
 
-.confirmation > button:hover {
+.options > button:hover {
   background-color: var(--color-secondary-20);
   cursor: pointer;
 }
 
-.confirmation .approve {
+.options .approve {
   background-color: var(--color-secondary-10);
   border: 1px solid var(--color-secondary-10);
 }

--- a/src/hooks/use-tab.ts
+++ b/src/hooks/use-tab.ts
@@ -1,0 +1,25 @@
+import shallow from "zustand/shallow";
+import { Variant } from "../lib/api";
+import { select } from "../lib/utils/select";
+import useEditorStore from "./editor-store";
+import useNavigationStore from "./navigation-store";
+
+export const useTab = () => {
+  const { closeTab, openTab } = useEditorStore(
+    select("openTab", "closeTab"),
+    shallow
+  );
+  const navigate = useNavigationStore((state) => state.navigate);
+  const close = (variant: string) => {
+    if (!closeTab(variant)) {
+      navigate("welcome");
+    }
+  };
+
+  const open = (variant: Variant) => {
+    navigate("editor");
+    openTab(variant);
+  };
+
+  return { close, open };
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -44,7 +44,7 @@ export const getTest = async (
 export const getVariant = async (
   file: string,
   config: ServiceConfig,
-  signal: AbortSignal
+  signal?: AbortSignal
 ) => {
   const service = new Service(config);
   return service.build.getVariant(file, { signal, headers: productHeader() });
@@ -72,7 +72,7 @@ export const deleteTest = async (
 export const deleteVariant = async (
   name: string,
   config: ServiceConfig,
-  signal: AbortSignal
+  signal?: AbortSignal
 ) => {
   const service = new Service(config);
   return service.build.deleteVariant(name, {


### PR DESCRIPTION
This PR add buttons to the security tests overlay that allows opening and deleting variants.

![open-delete](https://user-images.githubusercontent.com/760470/203918397-0161feca-662c-4a1b-969c-9c8ae0fc0f4c.gif)
