### PR TITLE
feat: Prompt for existing account

### DIFF
--- a/src/components/terminal/commands.module.css
+++ b/src/components/terminal/commands.module.css
@@ -152,6 +152,11 @@
   color: var(--gray-10);
 }
 
+.helpText a {
+  color: var(--white);
+  cursor: pointer;
+}
+
 .question {
   display: flex;
   gap: 0.25rem;

--- a/src/components/terminal/commands.module.css
+++ b/src/components/terminal/commands.module.css
@@ -155,6 +155,11 @@
 .helpText a {
   color: var(--white);
   cursor: pointer;
+  font-weight: bold;
+}
+
+.helpText a:hover {
+  text-decoration: dashed underline;
 }
 
 .question {

--- a/src/components/terminal/welcome-message.tsx
+++ b/src/components/terminal/welcome-message.tsx
@@ -1,10 +1,13 @@
 import { Credentials } from "@theprelude/sdk";
+import { useConfig } from "../../hooks/use-config";
 import styles from "./commands.module.css";
 
 const WelcomeMessage: React.FC<{ host: string; credentials?: Credentials }> = ({
   host,
   credentials,
 }) => {
+  const { handleImport } = useConfig();
+
   if (host && credentials) {
     return (
       <div className={styles.welcomeMessage}>
@@ -25,7 +28,22 @@ const WelcomeMessage: React.FC<{ host: string; credentials?: Credentials }> = ({
       Welcome to Prelude Build
       <br />
       <br />
-      <span className={styles.helpText}>type "use" to get started</span>
+      <span className={styles.helpText}>
+        already have an account?{" "}
+        <a
+          onClick={() => {
+            void handleImport();
+          }}
+        >
+          click here
+        </a>{" "}
+        to import it
+      </span>
+      <br />
+      <br />
+      <span className={styles.helpText}>
+        or type "use" to create a new account
+      </span>
     </div>
   );
 };

--- a/src/components/terminal/welcome-message.tsx
+++ b/src/components/terminal/welcome-message.tsx
@@ -37,7 +37,7 @@ const WelcomeMessage: React.FC<{ host: string; credentials?: Credentials }> = ({
         >
           click here
         </a>{" "}
-        to import it
+        to import credentials
       </span>
       <br />
       <br />

--- a/src/components/terminal/welcome-message.tsx
+++ b/src/components/terminal/welcome-message.tsx
@@ -2,11 +2,40 @@ import { Credentials } from "@theprelude/sdk";
 import { useConfig } from "../../hooks/use-config";
 import styles from "./commands.module.css";
 
-const WelcomeMessage: React.FC<{ host: string; credentials?: Credentials }> = ({
-  host,
-  credentials,
-}) => {
-  const { handleImport } = useConfig();
+const WelcomeMessage: React.FC<{
+  host: string;
+  credentials?: Credentials;
+  isNewAccount?: boolean;
+}> = ({ host, credentials, isNewAccount }) => {
+  const { handleImport, handleExport } = useConfig();
+
+  console.log(isNewAccount);
+
+  if (host && credentials && isNewAccount) {
+    return (
+      <div className={styles.welcomeMessage}>
+        account created.{" "}
+        <span className={styles.helpText}>
+          <a
+            onClick={() => {
+              void handleExport();
+            }}
+          >
+            click here
+          </a>{" "}
+          to backup credentials
+        </span>
+        <br />
+        <br />
+        Connected to {host}
+        <br />
+        <br />
+        <span className={styles.helpText}>
+          type "list-tests" to show all your tests
+        </span>
+      </div>
+    );
+  }
 
   if (host && credentials) {
     return (

--- a/src/hooks/use-config.tsx
+++ b/src/hooks/use-config.tsx
@@ -45,7 +45,12 @@ export const useConfig = () => {
     takeControl,
     write,
     reset: resetTerminal,
-  } = useTerminalStore(select("takeControl", "write", "reset"), shallow);
+    showIndicator,
+    hideIndicator,
+  } = useTerminalStore(
+    select("takeControl", "write", "reset", "showIndicator", "hideIndicator"),
+    shallow
+  );
 
   const resetEditor = useEditorStore((state) => state.reset);
   const navigate = useNavigationStore((state) => state.navigate);
@@ -61,6 +66,8 @@ export const useConfig = () => {
         );
         return;
       }
+
+      showIndicator("Importing credentials...");
 
       const authenticated = await login(
         {
@@ -95,6 +102,8 @@ export const useConfig = () => {
       }
 
       write(<ErrorMessage message="failed to import credentials" />);
+    } finally {
+      hideIndicator();
     }
   };
 

--- a/src/lib/commands/use-command.tsx
+++ b/src/lib/commands/use-command.tsx
@@ -54,7 +54,9 @@ export const useCommand: Command = {
 
       const newAccount = await createAccount(handle, signal);
 
-      return <WelcomeMessage host={host} credentials={newAccount} />;
+      return (
+        <WelcomeMessage host={host} credentials={newAccount} isNewAccount />
+      );
     } catch (e) {
       if (isExitError(e)) {
         return <TerminalMessage message="exited" />;


### PR DESCRIPTION
### Description

This PR aims to address #184 by adding a message prompting the use for an existing account when they open in the app in a new browser.

Additionally if the user calls the `use` command they will prompted to backup their credentials. If they are already logged in they will be prompted to override the existing account. 

#### Screenshots
<img width="1518" alt="Screenshot 2022-11-25 at 5 53 11 PM" src="https://user-images.githubusercontent.com/760470/204066402-9fec8712-70f2-44d8-afa3-8b37ca130abd.png">
<img width="1518" alt="Screenshot 2022-11-25 at 5 53 33 PM" src="https://user-images.githubusercontent.com/760470/204066406-5996ba6a-1857-4530-8193-e3977afd1e76.png">
<img width="1355" alt="Screenshot 2022-11-25 at 6 19 33 PM" src="https://user-images.githubusercontent.com/760470/204067147-410fcb23-27c1-41cd-b501-239f60d21b9b.png">

