### PR TITLE
Adding an alias for the Help command

### DIFF
--- a/src/lib/commands/index.tsx
+++ b/src/lib/commands/index.tsx
@@ -10,6 +10,7 @@ import { Command, Commands } from "./types";
 import { useCommand } from "./use-command";
 
 const helpCommand: Command = {
+  alias:["h"],
   hidden: () => true,
   exec() {
     const commandsList = Object.keys(commands)

--- a/src/lib/commands/index.tsx
+++ b/src/lib/commands/index.tsx
@@ -10,7 +10,7 @@ import { Command, Commands } from "./types";
 import { useCommand } from "./use-command";
 
 const helpCommand: Command = {
-  alias:["h"],
+  alias: ["h"],
   hidden: () => true,
   exec() {
     const commandsList = Object.keys(commands)


### PR DESCRIPTION
Per Octavia's suggestion (https://github.com/preludeorg/build/issues/187#issuecomment-1329512120) this PR adds an alias `h` for the help command.


<img width="1370" alt="Screen Shot 2022-11-28 at 1 07 41 PM" src="https://user-images.githubusercontent.com/84744117/204349422-c1a73f7c-6fe4-419e-ab2e-84e30cd63c73.png">
