### PR TITLE
Adding the same chevron animation for Variant Results

### DIFF
--- a/src/components/terminal/variant-results.module.css
+++ b/src/components/terminal/variant-results.module.css
@@ -50,6 +50,7 @@ ul {
   fill: var(--white);
   transform: rotate(180deg);
   margin-left: auto;
+  transition: transform 250ms;
 }
 
 .activeChevron {


### PR DESCRIPTION
This PR adds the same chevron transform delay as the tests and VST panels
https://user-images.githubusercontent.com/84744117/204403799-7bd66e9a-12c9-48ca-93c6-8bab5bc19361.mov

