### PR TITLE
Minor adjustments to credential overlay

### DIFF
--- a/src/components/status-bar/status-bar.module.css
+++ b/src/components/status-bar/status-bar.module.css
@@ -91,14 +91,28 @@
   position: absolute;
   z-index: 10;
   background: #21252b;
-  border: 1px solid #323844;
+  border: 1px solid var(--color-secondary-10);
   box-shadow: 12px 12px 15px rgba(0, 0, 0, 0.25);
   border-radius: 4px;
   bottom: 24px;
   display: flex;
   flex-direction: column;
+  row-gap: 0.5rem;
   padding: 0.75rem;
   width: max-content;
+}
+
+.popover .panel::before {
+  right: 70%;
+  bottom: 0;
+  position: absolute;
+  content: "";
+  padding: 0.2rem;
+  background-color: var(--color-secondary-30);
+  border-top: 1px solid var(--color-secondary-10);
+  border-right: 1px solid var(--color-secondary-10);
+  rotate: 135deg;
+  translate: 50% 50%;
 }
 
 .popover .panel a {


### PR DESCRIPTION
I felt like the credential overlay needed a bit more love so I gave it tiny treatments here. I matched the border color to the rest of our overlays and then added a caret pointing to the source. I also added a bit of padding between the options so its not so claustrophobic.
<img width="182" alt="Screen Shot 2022-11-29 at 9 56 08 AM" src="https://user-images.githubusercontent.com/84744117/204563432-0d89f536-43c0-410c-b23e-77a59bb69201.png">
