### PR TITLE
feat: Prevent changing prelude tests

### DIFF
--- a/apps/build/src/components/editor/window.tsx
+++ b/apps/build/src/components/editor/window.tsx
@@ -1,3 +1,4 @@
+import { EditorState } from "@codemirror/state";
 import { ServiceConfig } from "@theprelude/sdk";
 import classNames from "classnames";
 import React from "react";
@@ -42,17 +43,23 @@ const processVariant = debounce(saveVariant, 1000);
 const EditorWindow: React.FC = () => {
   const serviceConfig = useAuthStore(select("host", "credentials"), shallow);
   const tabKeys = useEditorStore((state) => Object.keys(state.tabs), shallow);
-  const { currentTabId, ext, buffer, updateBuffer } = useEditorStore(
+  const { currentTabId, ext, buffer, updateBuffer, readonly } = useEditorStore(
     (state) => ({
       currentTabId: state.currentTabId,
       ext: state.tabs[state.currentTabId].extension,
       updateBuffer: state.updateCurrentBuffer,
       buffer: selectBuffer(state),
+      readonly: state.tabs[state.currentTabId].variant.readonly ?? false,
     }),
     shallow
   );
 
-  const extensions = React.useMemo(() => getLanguage(ext).mode, [ext]);
+  console.log("readonly", readonly);
+
+  const extensions = React.useMemo(
+    () => [...getLanguage(ext).mode, EditorState.readOnly.of(readonly)],
+    [ext, readonly]
+  );
 
   return (
     <div className={styles.window}>

--- a/apps/build/src/components/editor/window.tsx
+++ b/apps/build/src/components/editor/window.tsx
@@ -54,8 +54,6 @@ const EditorWindow: React.FC = () => {
     shallow
   );
 
-  console.log("readonly", readonly);
-
   const extensions = React.useMemo(
     () => [...getLanguage(ext).mode, EditorState.readOnly.of(readonly)],
     [ext, readonly]

--- a/apps/build/src/lib/api.ts
+++ b/apps/build/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Service, ServiceConfig } from "@theprelude/sdk";
+import { Service, ServiceConfig, Test } from "@theprelude/sdk";
 import { isPWA } from "./utils/pwa";
 
 function productHeader(): HeadersInit {
@@ -10,6 +10,7 @@ function productHeader(): HeadersInit {
 export interface Variant {
   name: string;
   code: string;
+  readonly?: boolean;
 }
 
 export const newAccount = async (
@@ -127,3 +128,5 @@ export const createURL = async (name: string, config: ServiceConfig) => {
   const service = new Service(config);
   return await service.build.createURL(name, { headers: productHeader() });
 };
+
+export const isPreludeTest = (test: Test) => test.account_id === "prelude";

--- a/apps/build/src/lib/commands/create-variant-command.tsx
+++ b/apps/build/src/lib/commands/create-variant-command.tsx
@@ -12,7 +12,12 @@ import { terminalState } from "../../hooks/terminal-store";
 import focusTerminal from "../../utils/focus-terminal";
 import { createVariant, getVariant, Variant, variantExists } from "../api";
 import { getLanguage } from "../lang";
-import { isConnected, isExitError, isInTestContext } from "./helpers";
+import {
+  isConnected,
+  isExitError,
+  isInTestContext,
+  isPreludeTestContext,
+} from "./helpers";
 import { Command } from "./types";
 
 const platformValidator = z.enum(["*", "darwin", "linux", "windows"]);
@@ -65,7 +70,7 @@ export const createVariantCommand: Command = {
   alias: ["cv"],
   args: "[platform] [arch] [language]",
   desc: "create variant in current test",
-  enabled: () => isConnected() && isInTestContext(),
+  enabled: () => isConnected() && isInTestContext() && !isPreludeTestContext(),
   async exec(args) {
     const { takeControl, currentTest, showIndicator, hideIndicator } =
       terminalState();

--- a/apps/build/src/lib/commands/delete-test-command.tsx
+++ b/apps/build/src/lib/commands/delete-test-command.tsx
@@ -1,13 +1,13 @@
 import { terminalList } from "../../components/terminal/terminal-list";
 import {
-  TerminalMessage,
   ErrorMessage,
+  TerminalMessage,
 } from "../../components/terminal/terminal-message";
 import { authState } from "../../hooks/auth-store";
 import { editorState } from "../../hooks/editor-store";
 import { navigatorState } from "../../hooks/navigation-store";
 import { terminalState } from "../../hooks/terminal-store";
-import { deleteTest, getTestList } from "../api";
+import { deleteTest, getTestList, isPreludeTest } from "../api";
 import { isConnected, isExitError, isInTestContext } from "./helpers";
 import { NO_TESTS_MESSAGE } from "./messages";
 import { Command } from "./types";
@@ -31,13 +31,15 @@ export const deleteTestCommand: Command = {
       const { navigate } = navigatorState();
       const signal = takeControl().signal;
 
-      const tests = await getTestList(
-        {
-          host,
-          credentials,
-        },
-        signal
-      );
+      const tests = (
+        await getTestList(
+          {
+            host,
+            credentials,
+          },
+          signal
+        )
+      ).filter((test) => !isPreludeTest(test));
 
       if (tests.length === 0) {
         return NO_TESTS_MESSAGE;

--- a/apps/build/src/lib/commands/delete-variant-command.tsx
+++ b/apps/build/src/lib/commands/delete-variant-command.tsx
@@ -1,21 +1,26 @@
 import { terminalList } from "../../components/terminal/terminal-list";
 import {
-  TerminalMessage,
   ErrorMessage,
+  TerminalMessage,
 } from "../../components/terminal/terminal-message";
 import { authState } from "../../hooks/auth-store";
 import { editorState } from "../../hooks/editor-store";
 import { navigatorState } from "../../hooks/navigation-store";
 import { terminalState } from "../../hooks/terminal-store";
 import { deleteVariant, getTest } from "../api";
-import { isConnected, isExitError, isInTestContext } from "./helpers";
+import {
+  isConnected,
+  isExitError,
+  isInTestContext,
+  isPreludeTestContext,
+} from "./helpers";
 import { NO_VARIANTS_MESSAGE } from "./messages";
 import { Command } from "./types";
 
 export const deleteVariantCommand: Command = {
   alias: ["dv"],
   desc: "delete variant from current test",
-  enabled: () => isConnected() && isInTestContext(),
+  enabled: () => isConnected() && isInTestContext() && !isPreludeTestContext(),
   async exec() {
     const { currentTest, takeControl, showIndicator, hideIndicator } =
       terminalState();

--- a/apps/build/src/lib/commands/helpers.tsx
+++ b/apps/build/src/lib/commands/helpers.tsx
@@ -1,8 +1,14 @@
 import { authState } from "../../hooks/auth-store";
 import { terminalState } from "../../hooks/terminal-store";
+import { isPreludeTest } from "../api";
 
 export const isConnected = () => !!authState().credentials;
 export const isInTestContext = () => !!terminalState().currentTest;
+
+export const isPreludeTestContext = () => {
+  const currentTest = terminalState().currentTest;
+  return currentTest && isPreludeTest(currentTest);
+};
 
 export const isExitError = (e: unknown) => {
   if (!(e instanceof Error)) {

--- a/apps/build/src/lib/commands/list-variants-command.tsx
+++ b/apps/build/src/lib/commands/list-variants-command.tsx
@@ -8,7 +8,7 @@ import { editorState } from "../../hooks/editor-store";
 import { navigatorState } from "../../hooks/navigation-store";
 import { terminalState } from "../../hooks/terminal-store";
 import focusTerminal from "../../utils/focus-terminal";
-import { getTest, getVariant } from "../api";
+import { getTest, getVariant, isPreludeTest } from "../api";
 import { parseVariant } from "../utils/parse-variant";
 import { isConnected, isExitError, isInTestContext } from "./helpers";
 import { NO_VARIANTS_MESSAGE } from "./messages";
@@ -83,6 +83,7 @@ export const listVariantsCommand: Command = {
             return {
               name: v,
               code,
+              readonly: isPreludeTest(currentTest),
             };
           })
         );


### PR DESCRIPTION
### Descriptions

Prelude tests are now immutable and cannot be changed. This PR updates the UI to prevent the deleting and creating of variants under prelude tests.