### PR TITLE
fix: add typography according to Val's DS

### DIFF
--- a/apps/build/src/components/welcome/welcome.module.css
+++ b/apps/build/src/components/welcome/welcome.module.css
@@ -32,6 +32,7 @@
 
 .tagline {
   margin: 0;
+  font-size: var(--headline-sm);
 }
 
 .install {
@@ -92,6 +93,7 @@
 
 .title {
   margin: 0 0 16px;
+  font-size: var(--headline-sm);
 }
 
 @media (--bp-lg-only) {

--- a/apps/platform/src/components/header/header.module.css
+++ b/apps/platform/src/components/header/header.module.css
@@ -12,9 +12,8 @@
   padding: 0.75rem 0 0.75rem 0.75rem;
 }
 
-.brand h1 {
+.brand h4 {
   margin: 0;
-  font-size: var(--text-lg);
   line-height: 1.5rem;
 }
 

--- a/apps/platform/src/components/header/header.tsx
+++ b/apps/platform/src/components/header/header.tsx
@@ -18,7 +18,7 @@ const Header = () => {
       <section className={styles.brand}>
         <PreludeIcon className={styles.logo} />
         <span className={styles.divider} />
-        <h1>Build</h1>
+        <h4>Build</h4>
       </section>
       <section className={styles.right}>
         <Popover className={styles.account}>

--- a/packages/ds/src/components/overlay/overlay.module.css
+++ b/packages/ds/src/components/overlay/overlay.module.css
@@ -48,7 +48,7 @@
 }
 
 .legend {
-  font-size: var(--text-xxl);
+  font-size: var(--headline-rg);
   padding: 0.5rem;
   color: var(--white);
   display: flex;

--- a/packages/ds/src/styles/core/typography.css
+++ b/packages/ds/src/styles/core/typography.css
@@ -6,18 +6,22 @@
   /* set base values */
   --text-base: 16px;
 
-  /* type scale */
-  --text-xs: 0.75rem;
-  --text-sm: 0.875rem;
-  --text-lg: 1.25rem;
-  --text-xl: 1.5rem;
-  --text-xxl: 2rem;
-  --text-xxxl: 2.5rem;
+  /* headline type scale */
+  --headline-lg: 2.5; /* Large */
+  --headline-rg: 2rem; /* Regular */
+  --headline-sm: 1.5rem; /* Small */
+  --headline-xs: 1.125rem; /* Tiny */
+
+  /* text type scale */
+  --text-lg: 1.125rem; /* Large */
+  --text-rg: 1rem; /* Regular */
+  --text-sm: 0.875rem; /* Small */
+  --text-xs: 0.75rem; /* Tiny */
 
   /* button type scale  */
-  --button-sm: 0.875;
-  --button-rg: 1rem;
-  --button-lg: 1.125rem;
+  --button-lg: 1.125rem; /* Large */
+  --button-rg: 1rem; /* Regular */
+  --button-sm: 0.875; /* Small */
 }
 
 body {
@@ -37,22 +41,22 @@ form legend {
 
 /* text size */
 .text--xxxl {
-  font-size: var(--text-xxxl);
+  font-size: var(--headline-lg);
 }
 
 h1,
 .text--xxl {
-  font-size: var(--text-xxl);
+  font-size: var(--headline-lg);
 }
 
 h2,
 .text--xl {
-  font-size: var(--text-xl);
+  font-size: var(--headline-rg);
 }
 
 h3,
 .text--lg {
-  font-size: var(--text-lg);
+  font-size: var(--headline-sm);
 }
 
 .text--base {
@@ -61,7 +65,7 @@ h3,
 
 h4,
 .text--md {
-  font-size: var(--text-md);
+  font-size: var(--headline-xs);
 }
 
 .text--sm,


### PR DESCRIPTION
This PR standardizes the typography according to Val's design system he has in figma/zeplin. We had a mixed arrangement of them already but this PR lays it out how Val describes them so it should be easier for us to reference to.