### PR TITLE
fix: fixing obstructed settings overlay

### DIFF
--- a/apps/platform/src/components/header/header.module.css
+++ b/apps/platform/src/components/header/header.module.css
@@ -83,6 +83,7 @@
 
 .options {
   position: absolute;
+  z-index: 2;
   right: 0;
   top: 120%;
   display: flex;
@@ -112,6 +113,7 @@
 
 .options:before {
   content: "";
+  z-index: 2;
   right: 8%;
   top: -4%;
   position: absolute;
@@ -125,6 +127,7 @@
 
 .create {
   position: absolute;
+  z-index: 2;
   right: 0;
   top: 120%;
   display: flex;
@@ -138,6 +141,7 @@
 
 .create:before {
   content: "";
+  z-index: 2;
   translate: 25%;
   right: 6%;
   top: -2%;


### PR DESCRIPTION
Prior to this fix the settings overlay would be obstructed by the Editor and any other higher level z-indexed items. This PR sets the z-index to 10 which should help prevent that