### PR TITLE
fix: updating welcome screen to new design

### DIFF
--- a/apps/build/src/components/welcome/welcome.module.css
+++ b/apps/build/src/components/welcome/welcome.module.css
@@ -1,7 +1,7 @@
 /* Welcome Screen */
 
 .welcome {
-  padding: 1.5rem 3.125rem;
+  padding: 1.5rem;
 }
 
 @media (--bp-md) {
@@ -20,19 +20,15 @@
   flex-direction: row;
 }
 
-.wordmark {
-  fill: var(--white);
+.headline {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.5rem;
 }
 
-.line {
-  border-bottom: 1px solid var(--gray-30);
-  width: 57%;
-  margin: 1rem 0;
-}
-
-.tagline {
+.headline h2,
+.headline h4 {
   margin: 0;
-  font-size: var(--headline-sm);
 }
 
 .install {

--- a/apps/build/src/components/welcome/welcome.tsx
+++ b/apps/build/src/components/welcome/welcome.tsx
@@ -61,10 +61,9 @@ const Welcome = React.forwardRef<HTMLDivElement>(({}, ref) => {
   return (
     <div ref={ref} className={styles.welcome}>
       <header>
-        <section>
-          <PreludeWordmark className={styles.wordmark} />
-          <div className={styles.line} />
-          <h2 className={styles.tagline}>Security Test Authoring</h2>
+        <section className={styles.headline}>
+          <h2>Security Test Authoring</h2>
+          <h4>Create and manage your own security tests with Prelude Build</h4>
         </section>
         <section className={styles.install}>
           {!isInstalled && Boolean(installer) && (


### PR DESCRIPTION
This PR updates the welcome screen's headline as well as the padding for the screen according to Val's new designs.
<img width="1461" alt="Screen Shot 2022-12-07 at 7 04 30 PM" src="https://user-images.githubusercontent.com/84744117/206323781-95e0d191-05b3-48e8-be2d-70a633477d2e.png">
