### PR TITLE
fix: auto expand account manager

### DIFF
--- a/apps/platform/src/components/header/header.tsx
+++ b/apps/platform/src/components/header/header.tsx
@@ -76,8 +76,11 @@ const Header = () => {
     if (isAnonymous === true) {
       const button = Array.from(
         document.querySelectorAll("button") as NodeListOf<HTMLElement>
-      ).filter((b) => b.id.includes("headlessui-popover-button"))[0];
-
+      ).filter(
+        (b) =>
+          b.id.includes("headlessui-popover-button") &&
+          b.className.includes("tag")
+      )[0];
       button.click();
     }
   }, [isAnonymous]);

--- a/apps/platform/src/components/header/header.tsx
+++ b/apps/platform/src/components/header/header.tsx
@@ -74,9 +74,11 @@ const Header = () => {
 
   useEffect(() => {
     if (isAnonymous === true) {
-      (
-        document.getElementById("headlessui-popover-button-:r2:") as HTMLElement
-      ).click();
+      const button = Array.from(
+        document.querySelectorAll("button") as NodeListOf<HTMLElement>
+      ).filter((b) => b.id.includes("headlessui-popover-button"))[0];
+
+      button.click();
     }
   }, [isAnonymous]);
 


### PR DESCRIPTION
Took a bit of working around because the headless ui library doesn't allow for overwriting their id's and since we use react and they compile their classes with a randomized name there was no sure fire way to hit the element we wanted. This solution filters through all buttons on screen to check if they are a _headlessui-button_ and contain a specific tag used on the element we want. It's a hack around but the best way I could think of

https://user-images.githubusercontent.com/84744117/209168423-9e2d1e1f-2336-401e-ba58-dbd11b27489d.mov

