### PR TITLE
feat: tests are now single .go code files

### DIFF
--- a/apps/build/src/components/editor/control-panel.tsx
+++ b/apps/build/src/components/editor/control-panel.tsx
@@ -23,7 +23,7 @@ const ControlPanel: React.FC = () => {
     const tab = state.tabs[state.currentTabId];
 
     return {
-      validTest: validate(tab.buffer, getLanguage(tab.extension).linters),
+      validTest: validate(tab.buffer, getLanguage("go").linters),
       currentTabId: state.currentTabId,
     };
   }, shallow);

--- a/apps/build/src/components/editor/window.tsx
+++ b/apps/build/src/components/editor/window.tsx
@@ -64,7 +64,7 @@ const EditorWindow: React.FC = () => {
   );
 
   const extensions = React.useMemo(
-    () => [...getLanguage(ext).mode, EditorState.readOnly.of(readonly)],
+    () => [...getLanguage("go").mode, EditorState.readOnly.of(readonly)],
     [ext, readonly]
   );
 
@@ -136,7 +136,7 @@ const Tab: React.FC<{ tabId: string }> = ({ tabId }) => {
 const Linters: React.FC = () => {
   const messages = useEditorStore((state) => {
     const tab = state.tabs[state.currentTabId];
-    return lint(tab.buffer, getLanguage(tab.extension).linters);
+    return lint(tab.buffer, getLanguage("go").linters);
   }, shallow);
 
   if (messages.length === 0) return null;


### PR DESCRIPTION
Per my discussion with David, there are a few changes being made (WIP):

- [ ] Only `go` code files will be supported and the only option for users
- [ ] Dcf's will be compiled into versions for all platforms and architectures thus removing the need for variants
- [ ] With that tests will consist of a name and uncompiled code, only requiring the input of a name
- [ ] Deprecate variants and variant related commands