### PR TITLE
fix: only fetch tests once credentials are ready

### DIFF
--- a/apps/build/src/hooks/use-tests.ts
+++ b/apps/build/src/hooks/use-tests.ts
@@ -4,8 +4,10 @@ import shallow from "zustand/shallow";
 
 export const useTests = () => {
   const serviceConfig = useAuthStore(select("host", "credentials"), shallow);
-  const { data, isLoading } = useQuery(["tests", serviceConfig], () =>
-    listTests(serviceConfig)
+  const { data, isLoading } = useQuery(
+    ["tests", serviceConfig],
+    () => listTests(serviceConfig),
+    { enabled: !!serviceConfig.credentials }
   );
 
   return { data, isLoading };


### PR DESCRIPTION
### Description

This PR fixes an issue where the security tests are requested before account is created
