### PR TITLE
fix: adding text overflow for accordions

### DIFF
--- a/packages/ds/src/components/accordion/accordion.module.css
+++ b/packages/ds/src/components/accordion/accordion.module.css
@@ -43,6 +43,13 @@
   flex: 0.1;
 }
 
+.accordion > header > div {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The issue I saw was with large test names and it overflowing off the page and breaking the UI. My fix which may not be the route we decide to take was to add overflow css to the accordion itself, my thought being no accordions should allow for overflow. If we dont want to be that extreme, I can add a custom class for the test and then add an optional classname variable to accordions. lmk @kenrick 

<img width="1439" alt="Screen Shot 2023-01-04 at 3 55 03 PM" src="https://user-images.githubusercontent.com/84744117/210648210-a14b24a6-8959-43af-8a9d-5efd2df12484.png">
