### PR TITLE
fix: aligning padding between components for test accordion and create test

### DIFF
--- a/apps/build/src/components/browser/browser.module.css
+++ b/apps/build/src/components/browser/browser.module.css
@@ -4,3 +4,11 @@
   margin: 0;
   line-height: 3.5rem;
 }
+
+.accordion > header {
+  padding: 0.75rem 0.5rem 0.75rem 1rem;
+}
+
+.accordion > header > svg {
+  fill: var(--color-primary-10);
+}

--- a/apps/build/src/components/browser/create-test.module.css
+++ b/apps/build/src/components/browser/create-test.module.css
@@ -3,8 +3,7 @@
 .title {
   display: flex;
   flex-direction: row;
-
-  padding: 0.75rem;
+  padding: 0.75rem 0.5rem 0.75rem 1rem;
 }
 
 .title span {
@@ -26,7 +25,7 @@
   display: flex;
   flex-direction: row;
   column-gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 0.5rem 0.75rem 1rem;
   background-color: var(--transparent);
   align-items: center;
 }

--- a/apps/build/src/components/browser/verified-tests.tsx
+++ b/apps/build/src/components/browser/verified-tests.tsx
@@ -55,6 +55,7 @@ const TestItem: React.FC<{
       onToggle={accordion.toogle}
       title={test.rule}
       edit={<OpenButton test={test} readonly={readonly} />}
+      className={styles.accordion}
     >
       <AccordionList>
         {test.vst.map((vst) => (

--- a/apps/platform/src/components/banner/banner.module.css
+++ b/apps/platform/src/components/banner/banner.module.css
@@ -1,6 +1,6 @@
 .banner {
   display: flex;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0.75rem;
   background: var(--color-primary-20);
   font-size: var(--text-xs);
   align-items: center;

--- a/apps/platform/src/components/banner/banner.module.css
+++ b/apps/platform/src/components/banner/banner.module.css
@@ -12,3 +12,8 @@
   width: 1rem;
   height: 1rem;
 }
+
+.banner a {
+  color: var(--white);
+  text-underline-offset: 2px;  
+}

--- a/apps/platform/src/components/banner/banner.tsx
+++ b/apps/platform/src/components/banner/banner.tsx
@@ -13,7 +13,10 @@ const Banner: React.FC = () => {
     <div className={styles.banner}>
       <span className={styles.message}>
         Register an account using the account drop-down on the right to save
-        your work.
+        your work.{" "}
+        <a href="https://docs.prelude.org/docs/prelude-account" target="_blank">
+          Click here to learn more.
+        </a>
       </span>
 
       <IconButton icon={<CloseIcon />} onClick={() => setHide(true)} />

--- a/packages/ds/src/components/accordion/accordion.tsx
+++ b/packages/ds/src/components/accordion/accordion.tsx
@@ -10,12 +10,17 @@ export const Accordion: React.FC<{
   edit?: React.ReactNode;
   expanded: boolean;
   onToggle: () => void;
-}> = ({ title, children, expanded, edit, loading, onToggle }) => {
+  className?: string;
+}> = ({ title, children, expanded, edit, loading, onToggle, className }) => {
   return (
     <div
-      className={classNames(styles.accordion, {
-        [styles.active]: expanded,
-      })}
+      className={classNames(
+        styles.accordion,
+        {
+          [styles.active]: expanded,
+        },
+        className
+      )}
     >
       <header onClick={onToggle}>
         <div>{title}</div>


### PR DESCRIPTION
This PR does some padding work to align everything on the right hand side per Val's design. I also added an optional className param for accordions for future use of customization for it. In this scenario I added custom padding and proper fill color for caret svg.

<img width="435" alt="Screen Shot 2023-01-05 at 11 24 27 AM" src="https://user-images.githubusercontent.com/84744117/210829963-8459d84a-732e-4893-8832-5680fb0259c4.png">
