### PR TITLE
fix: making the GO template consistent with CLI

### DIFF
--- a/apps/build/src/components/browser/create-test.tsx
+++ b/apps/build/src/components/browser/create-test.tsx
@@ -28,8 +28,8 @@ const createNewTest = async (rule: string, serviceConfig: ServiceConfig) => {
   const testId = uuid.v4();
   const filename = `${testId}.go`;
   const code = getLanguage("go")
-    .template.replaceAll("$NAME", testId)
-    .replaceAll("$QUESTION", rule)
+    .template.replaceAll("$FILENAME", filename)
+    .replaceAll("$RULE", rule)
     .replaceAll("$CREATED", format(new Date(), "yyyy-MM-dd hh:mm:ss.SSSSSS"));
   if (serviceConfig.credentials === undefined) {
     throw new Error("Missing credentials");

--- a/apps/build/src/lib/lang/templates/template.go
+++ b/apps/build/src/lib/lang/templates/template.go
@@ -1,30 +1,30 @@
 /*
-NAME: $NAME
-QUESTION: $QUESTION
+FILENAME: $FILENAME
+RULE: $RULE
 CREATED: $CREATED
 */
 package main
 
 import (
-    "fmt"
-    "os"
+  "fmt"
+  "os"
 )
 
 func test() {
-    fmt.Println("Run test")
-    os.Exit(100)
+  fmt.Println("Run test")
+  os.Exit(100)
 }
 
 func clean() {
-    fmt.Println("Clean up")
-    os.Exit(100)
+  fmt.Println("Clean up")
+  os.Exit(100)
 }
 
 func main() {
-    args := os.Args[1:]
-    if len(args) > 0 {
-        clean()
-    } else {
-        test()
-    }
+	args := os.Args[1:]
+	if len(args) > 0 {
+		clean()
+	} else {
+		test()
+	}
 }


### PR DESCRIPTION
One thing to note, this fixes the build template but @makk94 and I decided that we are changing `name` to `filename` so this will have to be updated in the CLI too