### PR TITLE
Feat: More delete test button treatment

### DIFF
--- a/apps/build/src/components/browser/verified-tests.tsx
+++ b/apps/build/src/components/browser/verified-tests.tsx
@@ -19,6 +19,7 @@ import {
   EditorIcon,
   notifyError,
   notifySuccess,
+  TrashcanIcon,
   useAccordion,
   VariantIcon,
 } from "@theprelude/ds";
@@ -71,7 +72,10 @@ const TestItem: React.FC<{
       onToggle={accordion.toogle}
       title={test.rule}
       edit={<OpenButton test={test} />}
-      remove={!isPreludeTest(test) && <DeleteButton test={test} />}
+      remove={
+        !isPreludeTest(test) &&
+        accordion.expanded && <DeleteButton test={test} />
+      }
       className={styles.accordion}
     >
       <AccordionList>
@@ -167,7 +171,7 @@ const DeleteButton: React.FC<{ test: Test }> = ({ test }) => {
   );
   return (
     <ConfirmDialog
-      children={<AccordionAction loading={isLoading} icon={<CloseIcon />} />}
+      children={<AccordionAction loading={isLoading} icon={<TrashcanIcon />} />}
       message={"Are you positive you want to delete this test?"}
       onAffirm={() => mutate(test.id)}
     ></ConfirmDialog>

--- a/apps/build/src/components/browser/verified-tests.tsx
+++ b/apps/build/src/components/browser/verified-tests.tsx
@@ -72,10 +72,7 @@ const TestItem: React.FC<{
       onToggle={accordion.toogle}
       title={test.rule}
       edit={<OpenButton test={test} />}
-      remove={
-        !isPreludeTest(test) &&
-        accordion.expanded && <DeleteButton test={test} />
-      }
+      remove={!isPreludeTest(test) && <DeleteButton test={test} />}
       className={styles.accordion}
     >
       <AccordionList>

--- a/packages/ds/src/components/accordion/accordion.tsx
+++ b/packages/ds/src/components/accordion/accordion.tsx
@@ -34,8 +34,8 @@ export const Accordion: React.FC<{
     >
       <header onClick={onToggle}>
         <div className={styles.title}>{title}</div>
-        {edit && <>{edit}</>}
         {remove && <>{remove}</>}
+        {edit && <>{edit}</>}
         {loading ? <Loading /> : <ChevronIcon className={styles.expand} />}
       </header>
       {expanded && children}

--- a/packages/ds/src/components/icons/trashcan-icon.tsx
+++ b/packages/ds/src/components/icons/trashcan-icon.tsx
@@ -1,4 +1,6 @@
-export const TrashcanIcon: React.FC<{ className?: string }> = ({ className }) => {
+export const TrashcanIcon: React.FC<{ className?: string }> = ({
+  className,
+}) => {
   return (
     <svg
       className={className}

--- a/packages/ds/src/components/icons/trashcan-icon.tsx
+++ b/packages/ds/src/components/icons/trashcan-icon.tsx
@@ -1,4 +1,4 @@
-export const Trashcan: React.FC<{ className?: string }> = ({ className }) => {
+export const TrashcanIcon: React.FC<{ className?: string }> = ({ className }) => {
   return (
     <svg
       className={className}


### PR DESCRIPTION
This PR does 3 things:

1. Sets the delete button to only be visible when the test is expanded - I like this a lot and also will reduce the number of miss clicks on the delete button.
2. Swaps out the delete button icon from `close` to `trashcan`
3. Updates the trashcan icon file to be more consistent with the rest